### PR TITLE
Avoid string on lud03 response type

### DIFF
--- a/src/rest/card/scan/get.ts
+++ b/src/rest/card/scan/get.ts
@@ -176,7 +176,7 @@ const handleScan = async (req: ExtendedRequest, res: Response) => {
     .status(200)
     .send(
       JSON.stringify(response, (_, v) =>
-        typeof v === 'bigint' ? String(v) : v,
+        typeof v === 'bigint' ? Number(v) : v,
       ),
     );
 };


### PR DESCRIPTION
### Problem
The LUD-03 spec states that the min and max withdrawable values on its interface needs to be a number. From my shallow understanding of the code this PR is touching, it was trying to guarantee no precision loss with big ints serializing it to string. This behavior might make sense most of the time, but in this particular situation it does violate the spec, which leads to some wallets to be incompatible (namely the wallets using servers with more strict type checking).

### Solution
I think this quick solution is just to cast to Number instead of string, guaranteeing adherence to the spec.

### Reference
https://github.com/lnurl/luds/blob/luds/03.md

cc @lorenzolfm for pointing this out
